### PR TITLE
:technologist: Add .clangd file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/Release

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 **/build/*
 **/CMakeUserPresets.json
+*/.DS_Store


### PR DESCRIPTION
Enable developers to use the clangd LSP with their text editor of choice such as VSCode, NVIM, Zed and many others support clangd.

Users should run `conan build .` to generate the necessary files for `clangd` to work.