### PR TITLE
:zap: Preload unwind instructions for cxa_throw & rethrow

### DIFF
--- a/benchmark/platforms/lpc4078.cpp
+++ b/benchmark/platforms/lpc4078.cpp
@@ -14,6 +14,7 @@
 
 #include <libhal-arm-mcu/dwt_counter.hpp>
 #include <libhal-arm-mcu/lpc40/clock.hpp>
+#include <libhal-exceptions/control.hpp>
 
 #include <resource_list.hpp>
 

--- a/demos/platforms/lpc4078.cpp
+++ b/demos/platforms/lpc4078.cpp
@@ -14,6 +14,7 @@
 
 #include <libhal-arm-mcu/dwt_counter.hpp>
 #include <libhal-arm-mcu/lpc40/clock.hpp>
+#include <libhal-exceptions/control.hpp>
 
 #include <resource_list.hpp>
 

--- a/demos/platforms/stm32f103c8.cpp
+++ b/demos/platforms/stm32f103c8.cpp
@@ -14,6 +14,7 @@
 
 #include <libhal-arm-mcu/dwt_counter.hpp>
 #include <libhal-arm-mcu/stm32f1/clock.hpp>
+#include <libhal-exceptions/control.hpp>
 
 #include <resource_list.hpp>
 

--- a/include/libhal-exceptions/control.hpp
+++ b/include/libhal-exceptions/control.hpp
@@ -53,5 +53,4 @@ std::terminate_handler set_terminate(
  * @return std::terminate_handler - the currently set terminate handler
  */
 std::terminate_handler get_terminate() noexcept;
-
 }  // namespace hal


### PR DESCRIPTION
On the stm32f103c8 benchmark "0% cleanup"

- 10x frames: 90us
- 30x frames: 189.6us
- 50x frames: 289.3us
- 70x frames: 389.2us (previously 422us)

Withe 70x test frames we've reduced the runtime by 32.8us.

All measurements were made using the HALbORD P3.0 logic analyzer @ 6MHz sample rate.

Resolves #1