### PR TITLE
:zap: (minor) Add nearpoint search support

### DIFF
--- a/datasheets/near_point/block_seperation.json
+++ b/datasheets/near_point/block_seperation.json
@@ -1,0 +1,21 @@
+{
+  "reg": [
+    {
+      "bits": 10,
+      "name": "inter-block offset",
+      "type": 6
+    },
+    {
+      "bits": 22,
+      "name": "block index",
+      "type": 5
+    }
+  ],
+  "config": {
+    "fontsize": 14,
+    "bits": 32,
+    "hflip": true,
+    "lanes": 1,
+    "compact": true
+  }
+}

--- a/datasheets/near_point/linear_near_point_entry.json
+++ b/datasheets/near_point/linear_near_point_entry.json
@@ -1,0 +1,21 @@
+{
+  "reg": [
+    {
+      "bits": 24,
+      "name": "entry number offset",
+      "type": 5
+    },
+    {
+      "bits": 8,
+      "name": "average function size",
+      "type": 6
+    }
+  ],
+  "config": {
+    "fontsize": 14,
+    "bits": 32,
+    "hflip": true,
+    "lanes": 1,
+    "compact": true
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,39 @@
+# Scripts
+
+The scripts for testing and playing around with libhal exceptions.
+
+## Near Point Script?
+
+```plaintext
+usage: nearpoint.py [-h] [-b BLOCK_POWER] [-s SMALL_BLOCK_POWER] [-n] file
+
+positional arguments:
+  file                  text file with a list of function addresses in your code starting from 0 to N where N is the last function
+                        address, or output from the command: nm app.elf --size-sort --radix=d | grep " [Tt] " | awk '{print $1}'
+
+options:
+  -h, --help            show this help message and exit
+  -b BLOCK_POWER, --block_power BLOCK_POWER
+                        Set the block size based on a power of 2.
+  -s SMALL_BLOCK_POWER, --small_block_power SMALL_BLOCK_POWER
+                        Set the small block size based on a power of 2.
+  -n, --nm              The input file is actually output from an NM command: nm app.elf --size-sort --radix=d | grep " [Tt] " | awk
+                        '{print $1}'
+```
+
+The script works with output from nm following this:
+
+```bash
+python3 nearpoint.py --tool-prefix="/path/to/arm-none-eabi/bin/" --map="app.elf.map" app.elf
+```
+
+After
+
+What this will do is create a size sorted list of each function in the program
+and output its starting address. This easy to execute script enable 3rd parties
+to send us this information in a mostly erased fashion to compare against our
+application. Even if the application does not use exceptions.
+
+```bash
+python3 scripts/nearpoint.py demos/multi_levels.elf.nm -n -b 10
+```

--- a/scripts/archived/gen_sorted_linkscript.py
+++ b/scripts/archived/gen_sorted_linkscript.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+import subprocess
+import re
+import argparse
+import csv
+from typing import NamedTuple, List
+
+
+class Function(NamedTuple):
+    name: str
+    size: int
+    orig_addr: int
+    new_addr: int
+    index: int
+
+
+def get_sorted_functions(binary_path: str) -> List[Function]:
+    """Get size-sorted functions using nm and calculate new addresses."""
+    try:
+        cmd = ['nm', '--size-sort', '--print-size', binary_path]
+        nm_output = subprocess.check_output(
+            cmd, universal_newlines=True, stderr=subprocess.PIPE)
+
+        # First pass to get functions and find lowest address
+        temp_functions = []
+        lowest_addr = float('inf')
+        for line in nm_output.splitlines():
+            if ' t ' in line or ' T ' in line:
+                parts = line.strip().split()
+                if len(parts) >= 4:
+                    addr = int(parts[0], 16)
+                    size = int(parts[1], 16)
+                    name = parts[3]
+                    lowest_addr = min(lowest_addr, addr)
+                    temp_functions.append((name, size, addr))
+
+        # Sort by size in descending order
+        temp_functions.sort(key=lambda x: x[1], reverse=True)
+
+        # Calculate new sequential addresses
+        current_addr = lowest_addr
+        functions = []
+        for idx, (name, size, orig_addr) in enumerate(temp_functions):
+            functions.append(
+                Function(name, size, orig_addr, current_addr, idx))
+            # Align next address to 4-byte boundary
+            current_addr = (current_addr + size + 3) & ~3
+
+        return functions
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error running nm: {e}")
+        print(f"stderr: {e.stderr}")
+        return []
+
+
+def generate_linker_section(functions: List[Function]) -> str:
+    """Generate linker script section with sorted functions."""
+    script = []
+    script.append("SECTIONS")
+    script.append("{")
+    script.append("  .text :")
+    script.append("  {")
+
+    # Add functions in size order
+    for func in functions:
+        script.append(f"    KEEP(*(.text.{func.name}))")
+
+    # Add any remaining text sections
+    script.append("    *(.text*)")
+    script.append("    *(.rodata*)")
+    script.append("  } > FLASH")
+    script.append("}")
+
+    return "\n".join(script)
+
+
+def write_csv(functions: List[Function], filepath: str):
+    """Write function information to CSV file."""
+    with open(filepath, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['Index Entry', 'Function Name', 'Address'])
+        for func in functions:
+            writer.writerow([func.index, func.name, hex(func.new_addr)])
+
+
+def format_size(size: int) -> str:
+    """Format size in bytes to human-readable format."""
+    if size < 1024:
+        return f"{size:>8} B"
+    elif size < 1024 * 1024:
+        return f"{size/1024:>7.1f} KB"
+    else:
+        return f"{size/1024/1024:>7.1f} MB"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate size-sorted linker script section and CSV from ELF file'
+    )
+    parser.add_argument('binary', help='Path to the ELF binary')
+    parser.add_argument('-o', '--output', help='Output linker script file')
+    parser.add_argument('-c', '--csv', help='Output CSV file')
+    parser.add_argument('--summary', action='store_true',
+                        help='Show size summary of functions')
+    args = parser.parse_args()
+
+    # Get sorted functions
+    functions = get_sorted_functions(args.binary)
+
+    if not functions:
+        print("No functions found in binary")
+        return
+
+    # Generate linker script
+    linker_script = generate_linker_section(functions)
+
+    # Output handling for linker script
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(linker_script)
+        print(f"Linker script written to: {args.output}")
+    else:
+        print("\nLinker Script Section:")
+        print("=" * 80)
+        print(linker_script)
+        print("=" * 80)
+
+    # Output CSV if requested
+    if args.csv:
+        write_csv(functions, args.csv)
+        print(f"CSV file written to: {args.csv}")
+
+    # Print summary if requested
+    if args.summary:
+        total_size = sum(f.size for f in functions)
+        print("\nFunction Size Summary:")
+        print("-" * 90)
+        print(f"{'Index':>5} {'Size':>10} {'New Addr':>12} {'Function Name':<50}")
+        print("-" * 90)
+
+        for func in functions:
+            print(
+                f"{func.index:>5} {format_size(func.size)} {func.new_addr:>#12x} {func.name:<50}")
+
+        print("-" * 90)
+        print(f"Total Functions: {len(functions)}")
+        print(f"Total Size: {format_size(total_size)}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/archived/nearpoint-v2.py
+++ b/scripts/archived/nearpoint-v2.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+import subprocess
+import re
+import argparse
+import csv
+from typing import NamedTuple, List, Tuple, Optional
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+import numpy as np
+import math
+import logging
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+
+class Function(NamedTuple):
+    name: str
+    size: int
+    orig_addr: int
+    new_addr: int
+    index: int
+
+
+class Block:
+    def __init__(self, start_entry: int, end_entry: int):
+        self.start = start_entry
+        self.end = end_entry
+
+    def __repr__(self):
+        return f"Block(start='{self.start}', end={self.end})"
+
+
+class Equation:
+    def __init__(self, start_entry: int, average_function_size: int):
+        self.entry = start_entry
+        self.size = average_function_size
+
+    def __repr__(self):
+        return f"Equation(entry='{self.entry}', function_size={self.size})"
+
+    def to_u32(self, block_power: int) -> int:
+        LSB_TRIM = 2
+        SIZE_BIT_LIMIT = 9
+        SIZE_BIT_REDUCTION = LSB_TRIM + 3  # ERROR_ALLOWANCE_POWER
+        MAX_ALLOWED_BLOCK_SIZE = SIZE_BIT_LIMIT + SIZE_BIT_REDUCTION
+        BLOCK_SIZE = 1 << block_power
+        ERROR_ALLOWANCE = 1 << 3
+
+        if block_power > MAX_ALLOWED_BLOCK_SIZE:
+            raise Exception("Block power is too high! Must be below 14")
+
+        u32 = 0
+        if self.size < (BLOCK_SIZE / ERROR_ALLOWANCE):
+            u32 = self.size >> LSB_TRIM
+        u32 = u32 | (self.entry << SIZE_BIT_LIMIT)
+        return u32
+
+    def to_verbose_code(self, block_power: int) -> str:
+        LSB_TRIM = 2
+        SIZE_BIT_LIMIT = 9
+        SIZE_BIT_REDUCTION = LSB_TRIM + 3
+        MAX_ALLOWED_BLOCK_SIZE = SIZE_BIT_LIMIT + SIZE_BIT_REDUCTION
+        BLOCK_SIZE = 1 << block_power
+        ERROR_ALLOWANCE = 1 << 3
+
+        if block_power > MAX_ALLOWED_BLOCK_SIZE:
+            raise Exception("Block power is too high! Must be below 14")
+
+        final_size = 0
+        if self.size < (BLOCK_SIZE / ERROR_ALLOWANCE):
+            final_size = self.size >> LSB_TRIM
+
+        return f"({self.entry} << {SIZE_BIT_LIMIT}) | {final_size}"
+
+
+def get_sorted_functions(binary_path: str, tool_prefix: str = "") -> List[Function]:
+    """Extract functions that actually exist in final binary using objdump disassembly."""
+    objdump_cmd = f"{tool_prefix}objdump" if tool_prefix else "objdump"
+    nm_cmd = f"{tool_prefix}nm" if tool_prefix else "nm"
+
+    try:
+        # Step 1: Get real function addresses and names from disassembly (eliminates aliases)
+        cmd = [objdump_cmd, '-d', binary_path]
+        objdump_output = subprocess.check_output(
+            cmd, universal_newlines=True, stderr=subprocess.PIPE)
+
+        real_functions = {}
+        # Pattern matches: "00000840 <function_name>:"
+        for line in objdump_output.splitlines():
+            match = re.match(r'^([0-9a-f]{8}) <(.+?)>:$', line)
+            if match:
+                addr = int(match.group(1), 16)
+                name = match.group(2)
+                real_functions[addr] = name
+
+        if not real_functions:
+            logging.error("No functions found in disassembly")
+            return []
+
+        # Step 2: Get sizes using nm for functions that actually exist
+        cmd = [nm_cmd, '-S', '--size-sort', '--defined-only', binary_path]
+        nm_output = subprocess.check_output(
+            cmd, universal_newlines=True, stderr=subprocess.PIPE)
+
+        size_lookup = {}
+        for line in nm_output.splitlines():
+            if ' t ' in line or ' T ' in line:
+                parts = line.strip().split()
+                if len(parts) >= 4:
+                    addr = int(parts[0], 16)
+                    size = int(parts[1], 16)
+                    name = parts[3]
+                    # Only store sizes for functions that actually exist in disassembly
+                    if addr in real_functions and size > 0:
+                        size_lookup[addr] = size
+
+        # Step 3: Build final function list
+        functions = []
+        sorted_addrs = sorted(real_functions.keys())
+        lowest_addr = sorted_addrs[0] if sorted_addrs else 0
+        current_addr = lowest_addr
+
+        for idx, addr in enumerate(sorted_addrs):
+            name = real_functions[addr]
+            size = size_lookup.get(addr, 0)
+
+            # Calculate size from next function if not available from nm
+            if size == 0 and idx < len(sorted_addrs) - 1:
+                size = sorted_addrs[idx + 1] - addr
+            elif size == 0:
+                size = 4  # Default minimum size for last function
+
+            functions.append(Function(name, size, addr, current_addr, idx))
+            current_addr = (current_addr + size + 3) & ~3  # 4-byte align
+
+        # Sort by size descending and recalculate indices
+        functions.sort(key=lambda x: x.size, reverse=True)
+        current_addr = lowest_addr
+        for idx, func in enumerate(functions):
+            functions[idx] = Function(
+                func.name, func.size, func.orig_addr, current_addr, idx)
+            current_addr = (current_addr + func.size + 3) & ~3
+
+        return functions
+
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Error running {objdump_cmd}/{nm_cmd}: {e}")
+        return []
+
+
+def break_into_blocks(exception_index: list, block_power: int = 8):
+    if block_power < 3:
+        raise Exception("Block size power must be greater than 2")
+
+    BLOCK_SIZE = (1 << block_power) - 1
+    LAST_FUNCTION = exception_index[-1]
+    FIRST_FUNCTION = exception_index[0]
+    PROGRAM_LENGTH = LAST_FUNCTION - FIRST_FUNCTION
+    NUMBER_OF_BLOCKS = (PROGRAM_LENGTH >> block_power) + 1
+
+    block_list = [Block(0, 0)] * NUMBER_OF_BLOCKS
+    logging.debug(f"Created {len(block_list)} blocks")
+
+    index = 0
+    block_start_index = 0
+
+    # Lookup Table Region
+    while index < len(exception_index) - 1:
+        addr1 = exception_index[index] - FIRST_FUNCTION
+        addr2 = exception_index[index + 1] - FIRST_FUNCTION
+        function_size = addr2 - addr1
+
+        if function_size < BLOCK_SIZE:
+            break
+
+        starting_block = addr1 >> block_power
+        ending_block = addr2 >> block_power
+
+        for i in range(starting_block, ending_block):
+            if i < len(block_list):
+                block_list[i] = Block(index, index)
+
+        index += 1
+
+    logging.debug(f"Lookup Region Ends @ {index}")
+
+    # Grouped Function Region
+    block_start_index = index
+    while index < len(exception_index) - 1:
+        index += 1
+        BLOCK_START_ADDRESS = exception_index[block_start_index] - \
+            FIRST_FUNCTION
+        BLOCK_NUMBER_START = (BLOCK_START_ADDRESS >> block_power)
+
+        BLOCK_END_ADDRESS = exception_index[index] - FIRST_FUNCTION
+        BLOCK_NUMBER_END = (BLOCK_END_ADDRESS >> block_power)
+
+        BLOCK_INDEX_DELTA = (BLOCK_NUMBER_END - BLOCK_NUMBER_START)
+
+        if BLOCK_INDEX_DELTA == 1:
+            if BLOCK_NUMBER_START < len(block_list):
+                block_list[BLOCK_NUMBER_START] = Block(
+                    block_start_index, index)
+            block_start_index = index
+        elif BLOCK_INDEX_DELTA > 1:
+            logging.warning("Block delta > 1, adjusting...")
+
+    # Set the last block
+    if block_list:
+        block_list[-1] = Block(block_start_index, index)
+
+    return block_list
+
+
+def convert_blocks_to_linear_equations(blocks: list, exception_index: list, block_power: int = 8):
+    BLOCK_SIZE = 1 << block_power
+    equations = [Equation(0, 0)] * len(blocks)
+
+    for iter, block in enumerate(blocks):
+        start = block.start
+        end = block.end
+
+        if start == end:
+            equations[iter] = Equation(start, 0)
+            continue
+
+        index_slice = exception_index[start:end + 1]
+
+        # Perform linear fit
+        X = np.array(index_slice).reshape(-1, 1)
+        y = [*range(start, end + 1, 1)]
+
+        model = LinearRegression()
+        model.fit(X, y)
+
+        SLOPE = model.coef_[0]
+        if math.isclose(SLOPE, 0):
+            AVERAGE_SIZE = 0
+        else:
+            AVERAGE_SIZE = math.floor(1.0 / SLOPE)
+
+        if AVERAGE_SIZE <= BLOCK_SIZE:
+            equations[iter] = Equation(start, AVERAGE_SIZE)
+        else:
+            equations[iter] = Equation(start, 0)
+
+    return equations
+
+
+def predict_location(address: int, equations: list, block_power: int = 8):
+    INTER_BLOCK_MASK = (1 << block_power) - 1
+    INTER_BLOCK_LOCATION = address & INTER_BLOCK_MASK
+    EQUATION_INDEX = address >> block_power
+
+    if EQUATION_INDEX >= len(equations):
+        return len(equations) - 1
+
+    EQUATION = equations[EQUATION_INDEX]
+    START = EQUATION.entry
+
+    AVERAGE_FUNCTION_SIZE = EQUATION.size
+    if AVERAGE_FUNCTION_SIZE == 0:
+        return START
+
+    GUESS_OFFSET = math.ceil(INTER_BLOCK_LOCATION / AVERAGE_FUNCTION_SIZE)
+    LOCATION = START + GUESS_OFFSET
+
+    return LOCATION
+
+
+def function_entry_matches_address(address: int, exception_index: list, index: int):
+    if index >= len(exception_index) - 1:
+        return address >= exception_index[index]
+    else:
+        return (exception_index[index] <= address and
+                address < exception_index[index + 1])
+
+
+def prediction_error(address: int, exception_index: list, index: int):
+    if not (0 <= index <= len(exception_index) - 1):
+        index = min(max(index, 0), len(exception_index) - 1)
+
+    if function_entry_matches_address(address, exception_index, index):
+        return 0
+
+    if address < exception_index[index]:
+        for i in range(index, -1, -1):
+            if function_entry_matches_address(address, exception_index, i):
+                return i - index
+    if address >= exception_index[index]:
+        for i in range(index, len(exception_index)):
+            if function_entry_matches_address(address, exception_index, i):
+                return i - index
+
+    return len(exception_index) - index
+
+
+def calculate_error_stats(entries: list, equations: list, block_power: int,
+                          address_offset: int = 0, max_error_threshold: int = 8) -> Tuple[int, int, int]:
+    """Calculate error statistics and return (over_threshold_count, small_block_start, max_error)"""
+    over_threshold_count = 0
+    small_block_start = len(entries) - 1  # Default to end if no errors found
+    max_error = 0
+    first_error_found = False
+
+    for actual_entry_number, address in enumerate(entries):
+        NEW_ADDRESS = address - address_offset
+        estimated_entry_number = predict_location(
+            address=NEW_ADDRESS,
+            equations=equations,
+            block_power=block_power)
+
+        error = abs(estimated_entry_number - actual_entry_number)
+        if error > max_error:
+            max_error = error
+
+        if error > max_error_threshold:
+            over_threshold_count += 1
+            if not first_error_found:  # First error found
+                small_block_start = actual_entry_number
+                # Changed to INFO
+                logging.info(
+                    f"First error > {max_error_threshold} found at entry {small_block_start} with value {error}.")
+                first_error_found = True
+
+    return over_threshold_count, small_block_start, max_error
+
+
+def optimize_block_size(entries: list, start_power: int = 10, max_error_threshold: int = 8) -> Tuple[int, int]:
+    """Find optimal block sizes for normal and small tables"""
+    logging.info("Optimizing block sizes...")
+
+    best_normal_power = start_power
+    best_small_power = 7
+    best_score = float('inf')
+
+    # Test normal block powers
+    for normal_power in range(8, 15):
+        try:
+            blocks = break_into_blocks(entries, block_power=normal_power)
+            equations = convert_blocks_to_linear_equations(
+                blocks, entries, normal_power)
+            over_count, small_start, max_err = calculate_error_stats(
+                entries, equations, normal_power, 0, max_error_threshold)
+
+            # Score based on memory usage and error count
+            memory_usage = len(equations) * 4  # 4 bytes per equation
+            # Heavy penalty for errors
+            score = memory_usage + (over_count * 1000)
+
+            logging.debug(
+                f"Normal power {normal_power}: {len(equations)} blocks, {over_count} errors, score {score}")
+
+            if score < best_score:
+                best_score = score
+                best_normal_power = normal_power
+
+        except Exception as e:
+            logging.debug(f"Normal power {normal_power} failed: {e}")
+            continue
+
+    # Test small block powers (should be smaller than normal)
+    for small_power in range(5, min(best_normal_power, 12)):
+        try:
+            # Test with a small subset to see if it would work
+            test_entries = entries[-1000:] if len(entries) > 1000 else entries
+            blocks = break_into_blocks(test_entries, block_power=small_power)
+            equations = convert_blocks_to_linear_equations(
+                blocks, test_entries, small_power)
+            over_count, _, max_err = calculate_error_stats(
+                test_entries, equations, small_power, 0, max_error_threshold)
+
+            if over_count == 0:  # Found a good small block size
+                best_small_power = small_power
+                break
+
+        except Exception as e:
+            logging.debug(f"Small power {small_power} failed: {e}")
+            continue
+
+    logging.info(f"Optimal block sizes: normal={best_normal_power} (2^{best_normal_power}={1<<best_normal_power}), "
+                 f"small={best_small_power} (2^{best_small_power}={1<<best_small_power})")
+
+    return best_normal_power, best_small_power
+
+
+def make_smaller_block_table(small_block_start: int, entries: list, block_power: int):
+    """Create small table starting from where normal table errors exceed threshold"""
+    SMALL_TABLE_ADDRESS = entries[small_block_start]
+    SMALL_ENTRIES_SLICE = entries[small_block_start:]
+
+    logging.info(f"Small table covers entries {small_block_start} to {len(entries)-1} "
+                 f"(addresses 0x{SMALL_TABLE_ADDRESS:x} to 0x{entries[-1]:x})")
+
+    blocks = break_into_blocks(
+        exception_index=SMALL_ENTRIES_SLICE,
+        block_power=block_power)
+
+    equations = convert_blocks_to_linear_equations(
+        blocks=blocks,
+        exception_index=SMALL_ENTRIES_SLICE,
+        block_power=block_power)
+
+    return (equations, SMALL_TABLE_ADDRESS)
+
+
+def generate_linker_section(functions: List[Function], output_file: str):
+    """Generate linker script section with sorted functions."""
+    script_lines = []
+
+    # Add functions in size order
+    for func in functions:
+        script_lines.append(f"    KEEP(*(.text.{func.name}))")
+
+    # Write to file
+    with open(output_file, 'w') as f:
+        f.write('\n'.join(script_lines))
+        f.write('\n')
+
+    logging.info(f"Linker section written to: {output_file}")
+
+
+def generate_cpp_table_file(filename: str,
+                            equations: list,
+                            block_power: int,
+                            small_equations: list,
+                            small_block_start: int,
+                            small_table_address_start: int,
+                            small_block_power: int):
+    code = """#include <cstdint>
+#include <span>
+
+namespace hal::__except_abi {
+
+using u32 = std::uint32_t;
+using u32_span = std::span<std::uint32_t>;
+
+namespace {
+"""
+
+    code += "u32 _near_point_descriptor_data[] = {\n"
+    code += f"  0x{block_power:08x},\n"
+    code += f"  0x{small_block_power:08x},\n"
+    code += f"  0x{small_block_start:08x},\n"
+    code += f"  0x{small_table_address_start:08x},\n"
+    code += "};\n\n"
+
+    code += "u32 _normal_table_data[] = {\n"
+    for equation in equations:
+        code += f"  {equation.to_verbose_code(block_power)}, // entry={equation.entry}, size={equation.size}\n"
+    code += "};\n\n"
+
+    code += "u32 _small_table_data[] = {\n"
+    if len(small_equations) == 0:
+        code += "  0,\n"
+    else:
+        for equation in small_equations:
+            code += f"  {equation.to_verbose_code(small_block_power)}, // entry={equation.entry}, size={equation.size}\n"
+    code += "};\n"
+    code += "}  // namespace\n\n"
+
+    code += "u32_span near_point_descriptor = _near_point_descriptor_data;\n"
+    code += "u32_span normal_table = _normal_table_data;\n"
+    code += "u32_span small_table = _small_table_data;\n\n"
+
+    code += "}  // namespace hal::__except_abi\n"
+
+    with open(filename, "w") as f:
+        f.write(code)
+
+    logging.info(f"C++ nearpoint tables written to: {filename}")
+
+
+def interactive_test(entries: list, equations: list, block_power: int,
+                     small_equations: list = None, small_block_start: int = 0,
+                     small_table_address_start: int = 0, small_block_power: int = 7):
+    """Interactive testing mode"""
+    logging.info(
+        "Entering interactive mode. Enter addresses to test, or non-integer to exit.")
+
+    guess_count = 0
+    while True:
+        try:
+            logging.info(f"guess #{guess_count}")
+            guess_count += 1
+            address = int(input("Provide a memory address: "))
+
+            if small_equations and address >= small_table_address_start:
+                logging.info("Using small table")
+                NEW_ADDRESS = address - small_table_address_start
+                guess_location = predict_location(
+                    address=NEW_ADDRESS,
+                    equations=small_equations,
+                    block_power=small_block_power)
+                guess_location += small_block_start
+                guess_location = max(0, min(guess_location, len(entries) - 1))
+                error = prediction_error(address=address,
+                                         exception_index=entries,
+                                         index=guess_location)
+            else:
+                guess_location = predict_location(address=address,
+                                                  equations=equations,
+                                                  block_power=block_power)
+                guess_location = max(0, min(guess_location, len(entries) - 1))
+                error = prediction_error(address=address,
+                                         exception_index=entries,
+                                         index=guess_location)
+
+            logging.info(f"guess_location = {guess_location}")
+            logging.info(f"ERROR = {error}")
+            if abs(error) > 8:
+                logging.warning(
+                    "Error distance is greater than a single cache line")
+
+        except ValueError:
+            break
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate nearpoint exception tables and linker script from ELF file'
+    )
+    parser.add_argument('elf_file', help='Path to the ELF binary')
+    parser.add_argument('-o', '--output', help='Output base name (default: elf filename)',
+                        default=None)
+    parser.add_argument('-b', '--block-power', type=int, default=0,
+                        help='Normal block size power of 2 (0 = auto-optimize)')
+    parser.add_argument('-s', '--small-block-power', type=int, default=0,
+                        help='Small block size power of 2 (0 = auto-optimize)')
+    parser.add_argument('-e', '--error-threshold', type=int, default=8,
+                        help='Error threshold for small table generation (default: 8, min: 4)')
+    parser.add_argument('-i', '--interactive', action='store_true',
+                        help='Enter interactive testing mode after generation')
+    parser.add_argument('--auto-optimize', action='store_true',
+                        help='Automatically find optimal block sizes')
+    parser.add_argument('--tool-prefix', type=str, default="",
+                        help='Toolchain prefix for objdump/nm (e.g., "arm-none-eabi-" or full path)')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Enable verbose logging')
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if args.error_threshold < 4:
+        logging.error("Error threshold must be at least 4")
+        return 1
+
+    # Get base output name
+    if args.output:
+        base_name = args.output
+    else:
+        base_name = Path(args.elf_file).stem
+
+    # Extract functions from ELF using objdump (avoids aliases!)
+    logging.info(
+        f"Extracting real functions from {args.elf_file} (no aliases)")
+    if args.tool_prefix:
+        logging.info(f"Using toolchain prefix: {args.tool_prefix}")
+
+    functions = get_sorted_functions(args.elf_file, args.tool_prefix)
+
+    if not functions:
+        logging.error("No functions found in ELF file")
+        return 1
+
+    logging.info(f"Found {len(functions)} real functions")
+
+    # Create entries list (addresses in size-sorted order)
+    entries = [func.new_addr for func in functions]
+    entries.append(entries[-1] + functions[-1].size)  # Add end address
+
+    # Determine block sizes
+    if args.auto_optimize or (args.block_power == 0):
+        normal_power, small_power = optimize_block_size(
+            entries, 10, args.error_threshold)
+    else:
+        normal_power = args.block_power if args.block_power > 0 else 10
+        small_power = args.small_block_power if args.small_block_power > 0 else 7
+
+    if normal_power <= small_power:
+        logging.error(
+            f"Normal block power ({normal_power}) must be greater than small block power ({small_power})")
+        return 1
+
+    logging.info(
+        f"Using block sizes: normal=2^{normal_power}={1<<normal_power}, small=2^{small_power}={1<<small_power}")
+
+    # Generate normal table
+    logging.info("Generating normal nearpoint table...")
+    blocks = break_into_blocks(entries, block_power=normal_power)
+    equations = convert_blocks_to_linear_equations(
+        blocks, entries, normal_power)
+
+    # Check if small table is needed
+    over_count, small_block_start, max_error = calculate_error_stats(
+        entries, equations, normal_power, 0, args.error_threshold)
+
+    logging.info(
+        f"Normal table: {len(equations)} blocks, {over_count} errors > {args.error_threshold}, max error: {max_error}")
+
+    small_equations = []
+    small_table_address_start = entries[-1]
+
+    if over_count > 0:
+        logging.info(
+            f"Generating small table starting at entry {small_block_start}")
+        small_equations, small_table_address_start = make_smaller_block_table(
+            small_block_start, entries, small_power)
+
+        # Verify small table performance
+        small_over_count, _, small_max_error = calculate_error_stats(
+            entries[small_block_start:], small_equations, small_power,
+            small_table_address_start, args.error_threshold)
+
+        logging.info(
+            f"Small table: {len(small_equations)} blocks, {small_over_count} errors > {args.error_threshold}, max error: {small_max_error}")
+
+    # Generate outputs
+    cpp_file = f"{base_name}.nearpoint.cpp"
+    linker_file = f"{base_name}.linker_section.ld"
+
+    generate_cpp_table_file(
+        cpp_file, equations, normal_power,
+        small_equations, small_block_start, small_table_address_start, small_power)
+
+    generate_linker_section(functions, linker_file)
+
+    # Summary
+    total_memory = len(equations) * 4 + len(small_equations) * \
+        4 + 16  # 16 bytes for descriptor
+    text_size = entries[-1] - entries[0]
+    overhead_percent = (total_memory / text_size) * 100
+
+    logging.info(f"\nSummary:")
+    logging.info(f"  Functions: {len(functions)}")
+    logging.info(
+        f"  Normal table: {len(equations)} entries ({len(equations) * 4} bytes)")
+    logging.info(
+        f"  Small table: {len(small_equations)} entries ({len(small_equations) * 4} bytes)")
+    logging.info(
+        f"  Total memory: {total_memory} bytes ({overhead_percent:.3f}% of .text size)")
+    logging.info(f"  Generated: {cpp_file}, {linker_file}")
+
+    # Interactive mode
+    if args.interactive:
+        interactive_test(entries, equations, normal_power,
+                         small_equations, small_block_start, small_table_address_start, small_power)
+
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/scripts/archived/nearpoint.py
+++ b/scripts/archived/nearpoint.py
@@ -1,0 +1,547 @@
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+import numpy as np
+import math
+import pprint
+import logging
+import argparse
+from pathlib import Path
+
+
+# Configure the logging module
+logging.basicConfig(level=logging.INFO)
+
+ERROR_ALLOWANCE_POWER = 3
+ERROR_ALLOWANCE = 1 << 3
+
+
+class Block:
+    def __init__(self, start_entry: int, end_entry: int):
+        self.start = start_entry
+        self.end = end_entry
+
+    def __repr__(self):
+        return f"Block(start='{self.start}', end={self.end})"
+
+
+def break_into_blocks(exception_index: list, block_power: int = 8):
+    logging.debug("break_into_blocks()")
+    if block_power < 3:
+        raise Exception("Block size power greater than 7")
+
+    BLOCK_SIZE = (1 << block_power) - 1
+    LAST_FUNCTION = exception_index[-1]
+    FIRST_FUNCTION = exception_index[0]
+    PROGRAM_LENGTH = LAST_FUNCTION - FIRST_FUNCTION
+    # + 1 to account for the tail end of the index
+    NUMBER_OF_BLOCKS = (PROGRAM_LENGTH >> block_power) + 1
+
+    block_list = [Block(0, 0)] * NUMBER_OF_BLOCKS
+    logging.info(f"len(block_list) = {len(block_list)}")
+
+    index = 0
+    block_start_index = 0
+
+    # Lookup Table Region
+    while index < len(exception_index) - 1:
+        addr1 = exception_index[index] - FIRST_FUNCTION
+        addr2 = exception_index[index + 1] - FIRST_FUNCTION
+        function_size = addr2 - addr1
+
+        if function_size < BLOCK_SIZE:
+            break
+
+        starting_block = addr1 >> block_power
+        ending_block = addr2 >> block_power
+
+        for i in range(starting_block, ending_block):
+            block_list[i] = Block(index, index)
+
+        index += 1
+
+    logging.info(f"Lookup Region Ends @ {index}")
+
+    # Grouped Function Region
+    block_start_index = index
+    while index < len(exception_index) - 1:
+        index += 1
+        BLOCK_START_ADDRESS = exception_index[block_start_index] - \
+            FIRST_FUNCTION
+        BLOCK_NUMBER_START = (BLOCK_START_ADDRESS >> block_power)
+
+        BLOCK_END_ADDRESS = exception_index[index] - FIRST_FUNCTION
+        BLOCK_NUMBER_END = (BLOCK_END_ADDRESS >> block_power)
+
+        BLOCK_INDEX_DELTA = (BLOCK_NUMBER_END - BLOCK_NUMBER_START)
+
+        if BLOCK_INDEX_DELTA == 1:
+            block_list[BLOCK_NUMBER_START] = Block(block_start_index, index)
+            block_start_index = index
+        elif BLOCK_INDEX_DELTA > 1:
+            raise Exception("Not sure what to do in this situation! 😅")
+
+    # Set the last block to the last block start index available
+    block_list[-1] = Block(block_start_index, index)
+
+    return block_list
+
+
+class Equation:
+    def __init__(self, start_entry: int, average_function_size: int):
+        self.entry = start_entry
+        self.size = average_function_size
+
+    def __repr__(self):
+        return f"Equation(entry='{self.entry}', function_size={self.size})"
+
+    def to_u32(self, block_power: int) -> int:
+        # Since ARM functions are 4-byte aligned, we can trim the least
+        # significant 2 bits as no function will have a function size that
+        # isn't some multiple of 4.
+        LSB_TRIM = 2
+        SIZE_BIT_LIMIT = 9
+        SIZE_BIT_REDUCTION = LSB_TRIM + ERROR_ALLOWANCE_POWER
+        MAX_ALLOWED_BLOCK_SIZE = SIZE_BIT_LIMIT + SIZE_BIT_REDUCTION
+        BLOCK_SIZE = 1 << block_power
+
+        if block_power > MAX_ALLOWED_BLOCK_SIZE:
+            raise Exception("Block power is too high! Must be below 14")
+
+        # Sets size to zero
+        # Zero is a sentinel value representing a block with less than 8
+        # functions within it.
+        u32 = 0
+
+        if self.size < (BLOCK_SIZE / ERROR_ALLOWANCE):
+            u32 = self.size >> LSB_TRIM
+            # Why minus 1? To expand the size you must do the following in C:
+            #
+            #    avg_size = (value & 0x1FF) << 2;
+            #
+            # The smallest function is 4 bytes so 4 >> 2 will result in 1.
+        u32 = u32 | (self.entry << SIZE_BIT_LIMIT)
+        return u32
+
+    def to_verbose_code(self, block_power: int) -> str:
+        # TODO(...): copy and paste of the above, should have a single function
+        # performing these calculations to eliminate divergence
+
+        # Since ARM functions are 4-byte aligned, we can trim the least
+        # significant 2 bits as no function will have a function size that
+        # isn't some multiple of 4.
+        LSB_TRIM = 2
+        SIZE_BIT_LIMIT = 9
+        SIZE_BIT_REDUCTION = LSB_TRIM + ERROR_ALLOWANCE_POWER
+        MAX_ALLOWED_BLOCK_SIZE = SIZE_BIT_LIMIT + SIZE_BIT_REDUCTION
+        BLOCK_SIZE = 1 << block_power
+
+        if block_power > MAX_ALLOWED_BLOCK_SIZE:
+            raise Exception("Block power is too high! Must be below 14")
+
+        # Sets size to zero
+        # Zero is a sentinel value representing a block with less than 8
+        # functions within it.
+        final_size = 0
+
+        if self.size < (BLOCK_SIZE / ERROR_ALLOWANCE):
+            final_size = self.size >> LSB_TRIM
+            # Why minus 1? To expand the size you must do the following in C:
+            #
+            #    avg_size = (value & 0x1FF) << 2;
+            #
+            # The smallest function is 4 bytes so 4 >> 2 will result in 1.
+
+        return f"({self.entry} << {SIZE_BIT_LIMIT}) | {final_size}"
+
+
+def convert_blocks_to_linear_equations(blocks: list,
+                                       exception_index: list,
+                                       block_power: int = 8):
+    BLOCK_SIZE = 1 << block_power
+    equations = [Equation(0, 0)] * len(blocks)
+
+    logging.debug("convert_blocks_to_linear_equations()")
+
+    for iter, block in enumerate(blocks):
+        start = block.start
+        end = block.end
+
+        if start == end:
+            equations[iter] = Equation(start, 0)
+            continue
+
+        index_slice = exception_index[start:end + 1]
+
+        # Perform linear fit
+        X = np.array(index_slice).reshape(-1, 1)
+        y = [*range(start, end + 1, 1)]
+
+        model = LinearRegression()
+        model.fit(X, y)
+
+        SLOPE = model.coef_[0]
+        if (math.isclose(SLOPE, 0)):
+            AVERAGE_SIZE = 0
+        else:
+            AVERAGE_SIZE = math.floor(1.0 / SLOPE)
+
+        if AVERAGE_SIZE <= BLOCK_SIZE:
+            equations[iter] = Equation(start, AVERAGE_SIZE)
+        else:
+            equations[iter] = Equation(start, 0)
+
+    return equations
+
+
+def predict_location(address: int, equations: list, block_power: int = 8):
+    INTER_BLOCK_MASK = (1 << block_power) - 1
+    INTER_BLOCK_LOCATION = address & INTER_BLOCK_MASK
+    EQUATION_INDEX = address >> block_power
+    EQUATION = equations[EQUATION_INDEX]
+    START = EQUATION.entry
+
+    logging.debug(f"> INTER_BLOCK_LOCATION = {INTER_BLOCK_LOCATION}")
+    logging.debug(f"> EQUATION_INDEX = {EQUATION_INDEX}")
+    logging.debug(f"> START = {START}")
+
+    AVERAGE_FUNCTION_SIZE = EQUATION.size
+    if AVERAGE_FUNCTION_SIZE == 0:
+        return START
+
+    GUESS_OFFSET = math.ceil(INTER_BLOCK_LOCATION / AVERAGE_FUNCTION_SIZE)
+
+    LOCATION = START + GUESS_OFFSET
+    logging.debug(f"> AVERAGE_FUNCTION_SIZE = {AVERAGE_FUNCTION_SIZE}")
+    logging.debug(f"> GUESS_OFFSET = {GUESS_OFFSET}")
+    logging.debug(f"> LOCATION = {LOCATION}")
+
+    return LOCATION
+
+
+def function_entry_matches_address(address: int, exception_index: list,
+                                   index: int):
+    if index >= len(exception_index) - 1:
+        return address >= exception_index[index]
+    else:
+        return (exception_index[index] <= address and
+                address < exception_index[index + 1])
+
+
+def prediction_error(address: int, exception_index: list, index: int):
+    if not (0 <= index and index <= len(exception_index) - 1):
+        logging.error("Index out of bounds! CLAMPING!!")
+        index = min(index, len(exception_index) - 1)
+
+    if function_entry_matches_address(address, exception_index, index):
+        return 0
+
+    if address < exception_index[index]:
+        for i in range(index, 0, -1):
+            if function_entry_matches_address(address, exception_index, i):
+                return i - index
+    if address > exception_index[index]:
+        for i in range(index, len(exception_index) - 1, 1):
+            if function_entry_matches_address(address, exception_index, i):
+                return i - index
+
+    return len(exception_index) - index
+
+
+def clamp(n, smallest, largest):
+    return max(smallest, min(n, largest))
+
+
+def write_error_csv(filename: str,
+                    entries: list,
+                    equations: list,
+                    block_power: int,
+                    address_offset: int = 0) -> int:
+    over_cache_miss_count = 0
+    small_block_start = 0
+    max_error = 0
+
+    with open(filename, "w") as f:
+        f.write(f"actual_entry_number,address,error\n")
+        for actual_entry_number, address in enumerate(entries):
+            NEW_ADDRESS = address - address_offset
+            estimated_entry_number = predict_location(
+                address=NEW_ADDRESS,
+                equations=equations,
+                block_power=block_power)
+            logging.debug(
+                f"est:{estimated_entry_number}, act:{actual_entry_number}")
+            logging.debug(
+                f"   ori:{address}, new:{NEW_ADDRESS}")
+            error = abs(estimated_entry_number - actual_entry_number)
+            if error > max_error:
+                max_error = error
+            f.write(f"{actual_entry_number},{address},{error}\n")
+            if error > 8:
+                over_cache_miss_count += 1
+                if small_block_start == 0:
+                    small_block_start = actual_entry_number
+                    logging.info(f"small_block_start = {small_block_start}")
+
+    logging.info(f"max_error = {max_error}")
+    return over_cache_miss_count, small_block_start
+
+
+def prompt_user_for_guess(entries: list,
+                          equations: list,
+                          block_power: int) -> int:
+    guess_count = 0
+    while True:
+        try:
+            logging.info(f"guess #{guess_count}")
+            guess_count += 1
+            address = int(input("Provide a memory address: "))
+            guess_location = predict_location(address=address,
+                                              equations=equations,
+                                              block_power=block_power)
+            guess_location = clamp(guess_location, 0, len(entries) - 1)
+            error = prediction_error(address=address,
+                                     exception_index=entries,
+                                     index=guess_location)
+            logging.info(f"ERROR = { error }")
+            if abs(error) > 8:
+                logging.warning(
+                    "Error distance is greater than a single cache line")
+        except ValueError:  # break if the input is not an integer
+            break
+
+
+def make_smaller_block_table(small_block_start: int,
+                             entries: list,
+                             block_power: int):
+    SMALL_TABLE_ADDRESS = entries[small_block_start]
+    SMALL_ENTRIES_SLICE = entries[small_block_start:]
+
+    blocks = break_into_blocks(
+        exception_index=SMALL_ENTRIES_SLICE,
+        block_power=block_power)
+
+    equations = convert_blocks_to_linear_equations(
+        blocks=blocks,
+        exception_index=SMALL_ENTRIES_SLICE,
+        block_power=block_power)
+
+    return (equations, SMALL_TABLE_ADDRESS)
+
+
+def prompt_user_for_guess_with_small(entries: list,
+                                     equations: list,
+                                     block_power: int,
+                                     small_equations: list,
+                                     small_block_start: int,
+                                     small_table_address_start: int,
+                                     small_block_power: int) -> int:
+    guess_count = 0
+    FINAL_EQUATION_BLOCK = small_table_address_start >> block_power
+    TOTAL_BLOCKS_NEEDED = len(small_equations) + FINAL_EQUATION_BLOCK
+    TOTAL_BYTES_NEEDED = TOTAL_BLOCKS_NEEDED * 4
+    FINAL_ENTRY_ADDRESS = entries[-1]
+    percent_increase = (TOTAL_BYTES_NEEDED / FINAL_ENTRY_ADDRESS) * 100
+    logging.info(
+        f"📏 total_blocks_needed = {TOTAL_BLOCKS_NEEDED} x 4B = {TOTAL_BYTES_NEEDED}, or +{percent_increase:.5f}%")
+    while True:
+        try:
+            logging.info(f"guess #{guess_count}")
+            guess_count += 1
+            address = int(input("Provide a memory address: "))
+
+            if address > small_table_address_start:
+                logging.warning("Using small table")
+                NEW_ADDRESS = address - small_table_address_start
+                logging.info(
+                    f"new address = {NEW_ADDRESS}, {small_table_address_start}")
+                guess_location = predict_location(
+                    address=NEW_ADDRESS,
+                    equations=small_equations,
+                    block_power=small_block_power)
+                guess_location += small_block_start - 1
+                guess_location = clamp(guess_location, 0, len(entries) - 1)
+                # We use the normal entries and address for prediction error
+                error = prediction_error(address=address,
+                                         exception_index=entries,
+                                         index=guess_location)
+            else:
+                guess_location = predict_location(address=address,
+                                                  equations=equations,
+                                                  block_power=block_power)
+                guess_location = clamp(guess_location, 0, len(entries) - 1)
+                error = prediction_error(address=address,
+                                         exception_index=entries,
+                                         index=guess_location)
+            logging.info(f"guess_location = {guess_location}")
+            logging.info(f"ERROR = { error }")
+            if abs(error) > 8:
+                logging.warning(
+                    "Error distance is greater than a single cache line")
+        except ValueError:  # break if the input is not an integer
+            break
+
+
+def generate_cpp_table_file(filename: str,
+                            equations: list,
+                            block_power: int,
+                            small_equations: list,
+                            small_block_start: int,
+                            small_table_address_start: int,
+                            small_block_power: int):
+    code = """
+#include <cstdint>
+
+#include <span>
+
+namespace hal::__except_abi {
+
+using u32 = std::uint32_t;
+using u32_span = std::span<std::uint32_t>;
+
+namespace {
+"""
+
+    code += "u32 _near_point_descriptor_data[] = {\n"
+    code += f"  0x{block_power:08x},\n"
+    code += f"  0x{small_block_power:08x},\n"
+    code += f"  0x{small_block_start:08x},\n"
+    code += f"  0x{small_table_address_start:08x},\n"
+    code += "};\n"
+    code += "\n\n"
+
+    code += "u32 _normal_table_data[] = {\n"
+    for equation in equations:
+        code += f"  {equation.to_verbose_code(block_power)},\n"
+    code += "};\n"
+
+    code += "u32 _small_table_data[] = {\n"
+    if len(small_equations) == 0:
+        code += "  0,\n"
+    else:
+        for equation in small_equations:
+            code += f"  {equation.to_verbose_code(small_block_power)},\n"
+    code += "};\n"
+    code += "}  // namespace\n\n"
+
+    code += "u32_span near_point_descriptor = _near_point_descriptor_data;\n"
+    code += "u32_span normal_table = _normal_table_data;\n"
+    code += "u32_span small_table = _small_table_data;\n"
+
+    code += "}  // namespace hal::__except_abi\n"
+
+    with open(filename, "w") as f:
+        f.write(code)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "file",
+        help="""text file with a list of function addresses in your code
+        starting from 0 to N where N is the last function address, or output
+        from the command: nm app.elf --size-sort --radix=d | grep " [Tt] " | awk '{print $1}'
+        """,
+        type=Path)
+    parser.add_argument(
+        "-b",
+        "--block_power",
+        help="Set the block size based on a power of 2.",
+        default=10,
+        type=int)
+    parser.add_argument(
+        "-s",
+        "--small_block_power",
+        help="Set the small block size based on a power of 2.",
+        default=7,
+        type=int)
+    parser.add_argument(
+        "-n",
+        "--nm",
+        help="""The input file is actually output from an NM command:
+
+        nm app.elf --size-sort --radix=d | grep " [Tt] " | awk '{print $1}'
+
+        """,
+        action='store_true')
+    args = parser.parse_args()
+
+    if args.nm:
+        with open(args.file) as f:
+            sorted_sizes = [int(line.strip()) for line in f]
+        sorted_sizes = sorted(sorted_sizes, reverse=True)
+        entries = []
+        function_address = 0
+        for next_function_size in sorted_sizes:
+            entries.append(function_address)
+            function_address += next_function_size
+        entries.append(function_address)
+    else:
+        with open(args.file) as f:
+            entries = [int(line.strip()) for line in f]
+    BLOCK_POWER = args.block_power
+    SMALL_BLOCK_POWER = args.small_block_power
+
+    if BLOCK_POWER <= SMALL_BLOCK_POWER:
+        logging.error(f"Block power must be greater than small block power!")
+        logging.error(f"Block power       = {BLOCK_POWER}")
+        logging.error(f"Small Block Power = {SMALL_BLOCK_POWER}")
+        exit(1)
+
+    BLOCK_SIZE = 1 << BLOCK_POWER
+    SMALL_BLOCK_SIZE = 1 << SMALL_BLOCK_POWER
+    logging.info(f"Block power = {BLOCK_POWER}, size = {BLOCK_SIZE}")
+    logging.info(
+        f"Small Block Power = {SMALL_BLOCK_POWER}, size = {SMALL_BLOCK_SIZE}")
+
+    blocks = break_into_blocks(entries, block_power=BLOCK_POWER)
+    logging.debug(pprint.pformat(blocks))
+
+    equations = convert_blocks_to_linear_equations(blocks=blocks,
+                                                   exception_index=entries, block_power=BLOCK_POWER)
+    logging.debug(pprint.pformat(equations))
+    logging.debug(f"len(equations) = {len(equations)}")
+    logging.debug(f"len(entries) = {len(entries)}")
+
+    over_cache_miss_count, small_block_start = write_error_csv(
+        filename=f"{args.file}.error.csv",
+        entries=entries,
+        equations=equations,
+        block_power=BLOCK_POWER)
+
+    logging.info(f"over_cache_miss_count={over_cache_miss_count}")
+
+    if over_cache_miss_count > 0:
+        (small_equations, small_table_address_start) = make_smaller_block_table(
+            small_block_start=small_block_start,
+            entries=entries,
+            block_power=SMALL_BLOCK_POWER)
+
+        write_error_csv(
+            filename=f"{args.file}.error_small.csv",
+            entries=entries[small_block_start:],
+            equations=small_equations,
+            block_power=SMALL_BLOCK_POWER,
+            address_offset=small_table_address_start,
+        )
+    else:
+        small_equations = []
+        small_block_start = len(entries) - 1
+        small_table_address_start = entries[-1]
+        small_block_power = SMALL_BLOCK_POWER
+
+    generate_cpp_table_file(filename=f"{args.file}.np.cpp",
+                            equations=equations,
+                            block_power=BLOCK_POWER,
+                            small_equations=small_equations,
+                            small_block_start=small_block_start,
+                            small_table_address_start=small_table_address_start,
+                            small_block_power=SMALL_BLOCK_POWER)
+
+    prompt_user_for_guess_with_small(
+        entries=entries,
+        equations=equations,
+        block_power=BLOCK_POWER,
+        small_equations=small_equations,
+        small_block_start=small_block_start,
+        small_table_address_start=small_table_address_start,
+        small_block_power=SMALL_BLOCK_POWER)

--- a/scripts/nearpoint.py
+++ b/scripts/nearpoint.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+import subprocess
+import re
+import argparse
+from typing import List
+import logging
+import struct
+from pathlib import Path
+from collections import defaultdict
+import statistics
+
+
+class FunctionInfo:
+    def __init__(self, name: str, address: int, size: int = 0):
+        self.name = name
+        self.address = address
+        self.size = size
+        self.unwind_info = 0xFFFFFFFF
+
+    def __repr__(self):
+        return f"FunctionInfo(name='{self.name}', address=0x{self.address:08x}, size={self.size})\n"
+
+
+class FunctionGroup:
+    """
+    Class that holds a group of functions with the same unwind info
+    """
+
+    def __init__(self, unwind_info: int):
+        self.unwind_info = unwind_info
+        self.functions: List[FunctionInfo] = []
+
+    def __repr__(self):
+        return f'FunctionGroup(info={self.unwind_info:08x}, functions={self.functions}'
+
+    def add(self, function: FunctionInfo):
+        self.functions.append(function)
+
+    def size(self):
+        sum = 0
+        for function in self.functions:
+            sum += function.size
+        return sum
+
+    def generate_order_list(self):
+        order = ""
+        for function in self.functions:
+            name = function.name
+            if name.startswith(".text."):
+                order += f"    *({name})\n"
+            else:
+                order += f"    {name}\n"
+        return order
+
+
+def read_disassembly_get_function(text_section_asm: str) -> List[FunctionInfo]:
+    actualized_functions: List[FunctionInfo] = []
+    lines = text_section_asm.splitlines()
+    for line in lines:
+        # format: "08000040 <_exit>:"
+        if line.startswith('\t') or line.startswith(' '):
+            continue
+        if not line.endswith(':'):
+            continue
+
+        pattern = r"^([0-9a-fA-F]+) <(.+)>:$"
+        matches = re.findall(pattern, line)
+        if matches:
+            for address_text, function in matches:
+                address = int(address_text, 16)
+                actualized_functions.append(
+                    FunctionInfo(name=function, address=address))
+        else:
+            logging.error("INVALID function string!!")
+            raise ValueError
+
+        # We have reached the end of the function space
+        if line.endswith("<__text_end>:"):
+            break
+
+    # ==========================================================================
+    # Step 3: Calculate function sizes for all functions by using the distance
+    # between functions.
+    # NOTE: from step 2, we end when we encounter __text_end which isn't a real # function but gives us the address passed the end.
+    # ==========================================================================
+
+    for i in range(1, len(actualized_functions)):
+        current = actualized_functions[i - 1]
+        next = actualized_functions[i]
+        current.size = (next.address - current.address)
+
+    # Remove __text_end from the actualized functions and what we have left is
+    # a list of ALL functions within the final binary
+    FINALIZED_FUNCTIONS = actualized_functions[:-1]
+
+    return FINALIZED_FUNCTIONS
+
+
+def parse_object_map_line(line):
+    # Split by whitespace to get the main components
+    parts = line.split()
+
+    # parts[0] = '.text'
+    # parts[1] = '0x0800391c'
+    # parts[2] = '0x378'
+    # parts[3] = '/Users/kammce/.conan2/p/.../libgcc.a(_arm_addsubdf3.o)'
+
+    address = int(parts[1], 16)  # Convert hex to int
+    size = int(parts[2], 16)     # Convert hex to int
+
+    # Extract the object file name from the path
+    full_path = parts[3]
+
+    # Find the part in parentheses (the object file)
+    if '(' in full_path and ')' in full_path:
+        start = full_path.rfind('(')  # Find last '('
+        end = full_path.rfind(')')    # Find last ')'
+        obj_file = full_path[start+1:end]  # Extract '_arm_addsubdf3.o'
+    else:
+        # If no parentheses, take the last part of the path
+        obj_file = full_path.split('/')[-1]
+
+    return address, size, obj_file
+
+
+def read_map_get_function(map_file_text: str) -> List[FunctionInfo]:
+    actualized_functions: List[FunctionInfo] = []
+    lines = map_file_text.split('\n')
+    text_only_lines: List[str] = []
+
+    for start in range(len(lines)):
+        if lines[start].startswith('.text'):
+            # Trim all lines before this line
+            lines = lines[start:]
+            break
+
+    for line in lines:
+        text_only_lines.append(line)
+        # Trim everything after the text section
+        if '__fini_array_end = .' in line:
+            break
+
+    for index in range(len(text_only_lines)):
+        line = text_only_lines[index]
+        # Start of a sectioned function
+        if line.startswith(' .text.'):
+            sections = line.strip().split(maxsplit=3)
+            symbol_name = sections[0]
+
+            if len(sections) == 1:
+                address_and_size = text_only_lines[index + 1].strip()
+                address_and_size_array = address_and_size.split(maxsplit=2)
+                address = int(address_and_size_array[0], 16)
+                size = int(address_and_size_array[1], 16)
+            elif len(sections) >= 3:
+                address = int(sections[1], 16)
+                size = int(sections[2], 16)
+            else:
+                logging.error(f"Invalid map section found: {sections}")
+                exit(1)
+        # Start of a function group
+        elif line.startswith(' .text '):
+            # if this is the case there is always another line right below it
+            address, size, object_file = parse_object_map_line(line)
+            # *_arm_addsubdf3.o(.text*)
+            symbol_name = "*" + object_file + "(.text*)"
+        else:
+            continue
+
+        logging.debug(
+            f"symbol_name = {symbol_name}, address={address}, size={size}")
+        actualized_functions.append(FunctionInfo(
+            name=symbol_name, address=address, size=size))
+
+    return actualized_functions
+
+
+def get_substring_after(main_string, delimiter):
+    index = main_string.rfind(delimiter)
+    if index == -1:
+        raise ValueError
+    else:
+        return main_string[index + len(delimiter):]
+
+
+class Block:
+    def __init__(self, start_entry: int, average_size: int):
+        self.start = start_entry
+        self.average_size = average_size
+
+    def __repr__(self):
+        return f"Block(start='{self.start}', avg_size={self.average_size})"
+
+    def as_c_bit_mask(self, block_power: int):
+        return f"({self.start} << {block_power}) | {self.average_size}"
+
+
+def break_into_blocks(exception_index: List[FunctionGroup],
+                      block_power: int = 10) -> List[Block]:
+    # TODO(kammce): Add support for small table
+    if block_power < 3:
+        raise Exception("Block size power must be greater than 2")
+
+    logging.info(f"len(exception_index) = {len(exception_index)}")
+
+    index_cursor = 0
+    start_index = 0
+    group_addresses: List[int] = []
+    address_space_sum = 0
+
+    for i, entry in enumerate(exception_index):
+        group_addresses.append(address_space_sum)
+        address_space_sum += entry.size()
+
+    logging.info(f"Exception index covers {address_space_sum}B of code")
+
+    BLOCK_SIZE = (1 << block_power) - 1
+    LAST_FUNCTION = group_addresses[-1]
+    FIRST_FUNCTION = group_addresses[0]
+    PROGRAM_LENGTH = LAST_FUNCTION - FIRST_FUNCTION
+    NUMBER_OF_BLOCKS = (PROGRAM_LENGTH >> block_power) + 1
+
+    block_list = [Block(0, 0)] * NUMBER_OF_BLOCKS
+    logging.info(f"Created {len(block_list)} blocks")
+
+    # Lookup Table Region
+    while index_cursor < len(group_addresses) - 1:
+        addr1 = group_addresses[index_cursor] - FIRST_FUNCTION
+        addr2 = group_addresses[index_cursor + 1] - FIRST_FUNCTION
+        function_size = addr2 - addr1
+
+        if function_size < BLOCK_SIZE:
+            break
+
+        starting_block = addr1 >> block_power
+        ending_block = addr2 >> block_power
+
+        for i in range(starting_block, ending_block):
+            if i < len(block_list):
+                block_list[i] = Block(index_cursor, 0)
+
+        index_cursor += 1
+
+    logging.debug(f"Lookup Region Ends @ {index_cursor}")
+
+    # Grouped Function Region
+    start_index = index_cursor
+    # Iterate through the address space, setting blocks as necessary. We skip
+    # the last block
+    while index_cursor < len(group_addresses) - 1:
+        index_cursor += 1
+        BLOCK_START_ADDRESS = group_addresses[start_index] - \
+            FIRST_FUNCTION
+        BLOCK_NUMBER_START = (BLOCK_START_ADDRESS >> block_power)
+        BLOCK_END_ADDRESS = group_addresses[index_cursor] - FIRST_FUNCTION
+        BLOCK_NUMBER_END = (BLOCK_END_ADDRESS >> block_power)
+        BLOCK_INDEX_DELTA = (BLOCK_NUMBER_END - BLOCK_NUMBER_START)
+
+        if BLOCK_INDEX_DELTA == 1:
+            if BLOCK_NUMBER_START < len(block_list):
+                EXCEPTION_SLICE = exception_index[start_index:index_cursor]
+                AVERAGE_SIZE = round(statistics.fmean(
+                    entry.size() for entry in EXCEPTION_SLICE))
+                block_list[BLOCK_NUMBER_START] = Block(
+                    start_index, AVERAGE_SIZE)
+            start_index = index_cursor
+        elif BLOCK_INDEX_DELTA > 1:
+            logging.warning("Block delta > 1, adjusting...")
+
+    # Setting final block
+    EXCEPTION_SLICE = exception_index[start_index:index_cursor]
+    AVERAGE_SIZE = round(statistics.fmean(
+        entry.size() for entry in exception_index[start_index:index_cursor]))
+    block_list[-1] = Block(start_index, AVERAGE_SIZE)
+
+    return block_list
+
+
+def generate_cpp_table_file(filename: str,
+                            block_power: int,
+                            blocks: List[Block],
+                            program_start: int):
+    # TODO(kammce): Add support for small table
+    code = """#include <cstdint>
+
+#include <array>
+#include <span>
+
+namespace ke::__except_abi::inline v1 {
+
+namespace {
+"""
+
+    code += "std::array<std::uint32_t, 2> const _near_point_descriptor_data = {\n"
+    code += f"  0x{block_power:08x},\n"
+    code += f"  0x{program_start:08x},\n"
+    code += "};\n\n"
+
+    code += f"std::array<std::uint32_t, {len(blocks)}> const _normal_table_data = {{\n"
+    for block in blocks:
+        code += f"  {block.as_c_bit_mask(block_power)}, // entry={block.start}, avg_size={block.average_size}\n"
+    code += "};\n\n"
+    code += "}  // namespace\n\n"
+
+    code += "std::span<std::uint32_t const> near_point_descriptor = _near_point_descriptor_data;\n"
+    code += "std::span<std::uint32_t const> normal_table = _normal_table_data;\n"
+    code += "}  // namespace ke::__except_abi::inline v1\n"
+
+    with open(filename, "w") as f:
+        f.write(code)
+
+    logging.info(f"C++ nearpoint tables written to: {filename}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate nearpoint exception tables and linker script from ELF file'
+    )
+    parser.add_argument('elf_file', help='Path to the ELF binary')
+    parser.add_argument('-o', '--output',
+                        help='Output name (default: elf_file.nearpoint.cpp)',
+                        default=None)
+    parser.add_argument('-b', '--block-power', type=int, default=0,
+                        help='Normal block size power of 2 (0 = auto-optimize)')
+    parser.add_argument('-s', '--small-block-power', type=int, default=0,
+                        help='Small block size power of 2 (0 = auto-optimize) (NOT CURRENTLY SUPPORTED!)')
+    parser.add_argument('-e', '--error-threshold', type=int, default=8,
+                        help='Error threshold for small table generation (default: 8, min: 4) (NOT CURRENTLY SUPPORTED!)')
+    parser.add_argument('--auto-optimize', action='store_true',
+                        help='Automatically find optimal block sizes (NOT CURRENTLY SUPPORTED!)')
+    parser.add_argument('--tool-prefix', type=str, default="",
+                        help='Toolchain prefix for objdump/nm (e.g., "arm-none-eabi-" or full path)')
+    parser.add_argument('-m', '--map', type=Path, required=True,
+                        help='Path to map file for executable')
+    parser.add_argument('-r', '--order_file', type=str,
+                        default="order.ld",
+                        help='Path to where to store the ordering file.')
+    parser.add_argument('-n', '--nearpoint_file', type=str,
+                        default="nearpoint.cpp",
+                        help='Path to where to store the nearpoint table.')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Enable verbose logging')
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+    tool_prefix = args.tool_prefix
+
+    objdump_cmd = f"{tool_prefix}/arm-none-eabi-objdump"
+
+    # ==========================================================================
+    # Step 0: Disassemble elf file with all sections
+    # ==========================================================================
+    disassembly_cmd = [objdump_cmd, '-d', '-s', args.elf_file]
+    disassembly = subprocess.check_output(
+        disassembly_cmd, universal_newlines=True, stderr=subprocess.PIPE)
+
+    # ==========================================================================
+    # Step 1: Extract the list of ACTUAL functions from the `.text` section.
+    # ==========================================================================
+
+    map_file = Path(args.map).read_text()
+    FINALIZED_FUNCTIONS = read_map_get_function(
+        map_file)
+    logging.debug(f"FINALIZED_FUNCTIONS = \n{FINALIZED_FUNCTIONS}")
+
+    # ==========================================================================
+    # Step 2: Parse the exception index
+    # ==========================================================================
+    # I, for the life of me, cannot understand why they put the index in the
+    # ordered area and the table in the ordered area. Might be a typo.
+    EXCEPTION_INDEX_SECTION_NAME = ".except_unordered:\n"
+    section_content = disassembly.split("Contents of section ")
+    exception_index = ""
+    for section in section_content:
+        if section.startswith(EXCEPTION_INDEX_SECTION_NAME):
+            exception_index = section
+            break
+
+    exception_index_text = exception_index.removeprefix(
+        EXCEPTION_INDEX_SECTION_NAME)
+    logging.debug(f"\n{exception_index_text}")
+
+    def parse_prel31(value):
+        """Convert PREL31 value to signed 32-bit integer"""
+        # Check if MSB (bit 30) is set for sign extension
+        if value & (1 << 30):
+            value |= 1 << 31
+        return struct.unpack('>i', struct.pack('>I', value))[0]
+
+    def parse_exception_index(hex_data: str):
+        """Parse exception index from hex dump"""
+        # Remove hex dump formatting and convert to bytes
+        hex_lines = hex_data.strip().split('\n')
+        hex_bytes = []
+        first_line = hex_lines[0].split()[0].zfill(8)
+        logging.debug(f'first_line = "{first_line}"')
+        initial_address_text = bytes.fromhex(first_line)
+        initial_address = struct.unpack('>I', initial_address_text)[0]
+        logging.debug(f'initial address = {initial_address:08x}')
+        # format:  800835c 00000000 e07cff7f 10ffff7f ec7cff7f  .....|.......|..
+
+        # For some reason there is a set of 0s at the start which puts
+        # everything off by 1. We need to handle this line outside of the loop
+        for line in hex_lines:
+            # Extract hex values after the address
+            address_and_values = (line.split("  ")[0]).strip()
+            logging.debug(f'address_and_values = {address_and_values}')
+            parts = address_and_values.split(" ")[1:]
+            logging.debug(f'parts = {parts}')
+            hex_bytes.extend(parts)
+
+        # Skip the first 0s in the index if it exists
+        if hex_bytes[0] == "00000000":
+            hex_bytes = hex_bytes[1:]
+        results: List[FunctionInfo] = []
+
+        # Process in pairs (skip first two, then take pairs)
+        for i in range(0, len(hex_bytes), 2):
+            if i + 1 >= len(hex_bytes):
+                break
+
+            addr_hex = hex_bytes[i]
+            offset_hex = hex_bytes[i + 1]
+            logging.debug(f"  addr_hex = {addr_hex}")
+            logging.debug(f"offset_hex = {offset_hex}")
+
+            addr_bytes = bytes.fromhex(addr_hex)
+            offset_bytes = bytes.fromhex(offset_hex)
+
+            addr_raw = struct.unpack('<I', addr_bytes)[0]
+            offset_raw = struct.unpack('<I', offset_bytes)[0]
+
+            # Apply PREL31 conversion
+            addr_prel31 = parse_prel31(addr_raw)
+            offset_prel31 = offset_raw
+
+            entry_offset = i * 4
+            absolute_address = (initial_address + entry_offset) + addr_prel31
+            logging.debug(
+                f"addr_prel31 = {addr_prel31} -> {absolute_address:08x}\n")
+
+            results.append((absolute_address, offset_prel31))
+
+        return results
+
+    EXCEPTION_ENTRIES = parse_exception_index(exception_index_text)
+
+    hex_values = ' '.join(
+        f'(function: {entry[0]:08x}, data: {entry[1]:08x}),\n' for entry in EXCEPTION_ENTRIES)
+    logging.debug(hex_values)
+
+    # ==========================================================================
+    # Step X: Set the unwind info for each function in the finalized_functions
+    # ==========================================================================
+    function_index = 0
+
+    for i in range(1, len(EXCEPTION_ENTRIES)):
+        entry_function, unwind_info = EXCEPTION_ENTRIES[i - 1]
+        next_entry_function, next_unwind_info = EXCEPTION_ENTRIES[i]
+
+        logging.debug(
+            f"entry_function: {entry_function:08x}, unwind: {unwind_info}, next_entry_function: {next_entry_function:08x}")
+
+        if FINALIZED_FUNCTIONS[function_index].address != entry_function:
+            # TODO(kammce): figure out better exception
+            logging.error(
+                f"entry_function({i}): {entry_function:08x} != {FINALIZED_FUNCTIONS[function_index].address:08x}:{FINALIZED_FUNCTIONS[function_index].name}")
+
+            # Print the last of functions
+            for i in range(function_index, len(FINALIZED_FUNCTIONS)):
+                function_symbol = FINALIZED_FUNCTIONS[i]
+                logging.error(f"[{i}] = {function_symbol}")
+
+            exit(1)
+
+        FINALIZED_FUNCTIONS[function_index].unwind_info = unwind_info
+        function_index = function_index + 1
+
+        while (FINALIZED_FUNCTIONS[function_index].address < next_entry_function):
+            if unwind_info & 1 << 31 or unwind_info == 1:
+                logging.debug(
+                    f"Set [{function_index}] = {FINALIZED_FUNCTIONS[function_index].address:08x}:{FINALIZED_FUNCTIONS[function_index].name} = {unwind_info:08x}")
+                FINALIZED_FUNCTIONS[function_index].unwind_info = unwind_info
+            else:
+                logging.debug(
+                    f"Transparent [{function_index}] = 0xFFFFFFFF")
+                FINALIZED_FUNCTIONS[function_index].unwind_info = 0xFFFFFFFF
+
+            function_index = function_index + 1
+
+    # Append the last of the functions
+    last_unwind_info = EXCEPTION_ENTRIES[-1][1]
+    if not (last_unwind_info & 1 << 31):
+        last_unwind_info = 0xFFFFFFFF
+    for i in range(function_index, len(FINALIZED_FUNCTIONS)):
+        FINALIZED_FUNCTIONS[i].unwind_info = last_unwind_info
+
+    # ==========================================================================
+    # Step 4: Collect functions into groups with common unwind info
+    # ==========================================================================
+    unwind_groups_map: defaultdict[int,
+                                   FunctionGroup] = {}
+    logging.debug("unwind_groups_map")
+    for function in FINALIZED_FUNCTIONS:
+        if function.unwind_info in unwind_groups_map:
+            unwind_groups_map[function.unwind_info].add(function)
+        else:
+            new_group = FunctionGroup(function.unwind_info)
+            new_group.add(function)
+            unwind_groups_map[function.unwind_info] = new_group
+
+    for unwind, value in unwind_groups_map.items():
+        logging.debug(f"unwind:  {unwind:08x}: >>> {value} <<<\n")
+
+    # ==========================================================================
+    # Step 5: Sort Function groups
+    # ==========================================================================
+    # Make a copy of the leaf functions because we are going to delete them
+    # from the unwind groups as they don't have unwind information.
+    leaf_functions = unwind_groups_map[0xFFFFFFFF]
+    unwind_groups_map.pop(0xFFFFFFFF)
+    # Add all of the leaf functions to the NOEXCEPT terminate group
+    for funct in leaf_functions.functions:
+        unwind_groups_map[1].add(funct)
+    sorted_unwind_groups_list = list(unwind_groups_map.values())
+    sorted_unwind_groups_list.sort(key=FunctionGroup.size, reverse=True)
+    logging.debug(f"Size sorted unwind groups\n")
+    for group in sorted_unwind_groups_list:
+        logging.debug(
+            f"group-[{group.unwind_info:08x}]: >>> {group.functions} <<<\n")
+
+    # ==========================================================================
+    # Step 6: Generate text ordering
+    # ==========================================================================
+    order_string = ""
+    order_string += "SECTIONS {\n"
+    order_string += "  .text.sorted : {\n"
+    order_string += "    /* LEAF & unsortable functions below */\n"
+    for group in sorted_unwind_groups_list:
+        # SECTIONS {
+        #     .text : {
+        order_string += f"    /* Unwind info 0x{group.unwind_info:08x} */\n"
+        order_string += group.generate_order_list()
+        #     }
+        # }
+        # INSERT BEFORE .text;
+    order_string += "  }\n"
+    order_string += "}\n"
+    order_string += "INSERT BEFORE .text;\n"
+    Path(args.order_file).write_text(order_string)
+    logging.info(
+        f"Function ordering linker script written to {args.order_file}")
+    logging.debug(order_string)
+
+    # ==========================================================================
+    # Step 7: Generate nearpoint table
+    # ==========================================================================
+    blocks = break_into_blocks(
+        sorted_unwind_groups_list, block_power=args.block_power)
+    logging.debug(f"blocks={blocks}")
+    generate_cpp_table_file(blocks=blocks,
+                            block_power=args.block_power,
+                            filename=args.nearpoint_file,
+                            program_start=FINALIZED_FUNCTIONS[0].address)
+
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/scripts/prel31.py
+++ b/scripts/prel31.py
@@ -1,0 +1,63 @@
+import struct
+import argparse
+import logging
+
+# format: 80084bc 14feff7f 38cbff7f 01000000 5ccbff7f
+
+
+def parse_prel31(address: int, prel31_offset: int, endianness: str = 'little'):
+    """Convert PREL31 value to signed 32-bit integer"""
+    # Handle endianness by byte-swapping if needed
+    if endianness == 'little':
+        # Convert displayed hex to actual little-endian value
+        offset_bytes = struct.pack('>I', prel31_offset)
+        offset = struct.unpack('<I', offset_bytes)[0]
+    else:
+        offset = prel31_offset
+
+    # Mask to 31 bits and sign extend
+    offset &= 0x7FFFFFFF
+    if offset & 0x40000000:  # Check bit 30 (sign bit)
+        offset -= 0x80000000
+
+    logging.debug(f"offset = {offset}")
+    return address + offset
+
+
+def parse_hex(value):
+    """Parse hex string or int"""
+    if isinstance(value, str) and value.startswith('0x'):
+        return int(value, 16)
+    return int(value)
+
+
+def main():
+    logging.getLogger().setLevel(logging.DEBUG)
+    parser = argparse.ArgumentParser(
+        description='Generate nearpoint exception tables and linker script from ELF file'
+    )
+    parser.add_argument('prel31_offset', help='value to convert',
+                        type=parse_hex)
+    parser.add_argument('-a', '--address',
+                        help='Address of the prel31 offset value which is needed to get an absolute value. The default of 0 returns the relative offset from the value',
+                        type=parse_hex,
+                        default=0)
+
+    parser.add_argument('-e', "--endian",
+                        help='Set the endianess of the prel31_offset. The address must be big endian (or the way its spelled)',
+                        type=str,
+                        choices=['big', 'little'],
+                        default='little')
+    args = parser.parse_args()
+
+    logging.info(
+        f"Address: {args.address:08x}, PREL31: {args.prel31_offset:08x}")
+    absolute_address = parse_prel31(
+        args.address, args.prel31_offset, args.endian)
+    logging.info(f"Result {absolute_address:08x}")
+
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -14,9 +14,7 @@
 
 
 from conan import ConanFile
-from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, cmake_layout
-import os
 
 
 class TestPackageConan(ConanFile):

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -17,11 +17,6 @@
 #include <libhal-exceptions/control.hpp>
 
 // NOLINTBEGIN(readability-identifier-naming)
-// NOLINTBEGIN(bugprone-reserved-identifier)
-// // These are just here to resolve linker errors. This will not work in
-// practice. std::uint64_t __extab_start = 0; std::uint64_t __extab_end = 0;
-// NOLINTEND(bugprone-reserved-identifier)
-
 struct V  // NOLINT(readability-identifier-naming)
 {
   int inner_detail_v = 0;
@@ -100,13 +95,4 @@ int main()
   } catch (error const&) {
     return -1;
   }
-}
-
-// These functions only exist here to link in a `start()` or `end()` function
-// which is used by the benchmark software to test the timing of operations.
-void start()
-{
-}
-void end()
-{
 }


### PR DESCRIPTION
Nearpoint search reduces the time required to perform an exception entry lookup by grouping transparent functions by their unwind information and sorting all groups of functions by size from largest to smallest. This ordering allows for a lookup table to be built that can provide information of where to find an exception entry. The goal for valid nearpoint tables is to ensure that for all inputs, every output is within 8 entries of the desired entry.

The current format of the nearpoint table and descriptors is experimental and thus may change between new updates.